### PR TITLE
Fix village build with Paper 1.20.6

### DIFF
--- a/example/village/HouseBuilder.java
+++ b/example/village/HouseBuilder.java
@@ -99,6 +99,18 @@ public final class HouseBuilder {
     }
 
     /* ------------------------------------------------------------------ */
+    /*  NOUVELLE MÉTHODE utilitaire : peint 1 bloc de route               */
+    /* ------------------------------------------------------------------ */
+    public static void paintRoad(Queue<Runnable> q,
+                                 List<Material> palette,
+                                 int x, int y, int z,
+                                 TerrainManager.SetBlock sb) {
+        Random R = new Random();
+        Material m = palette.get(R.nextInt(palette.size()));
+        q.add(() -> sb.set(x, y, z, m));
+    }
+
+    /* ------------------------------------------------------------------ */
     /* CHAMP (farmland + eau + cultures)                                  */
     /* ------------------------------------------------------------------ */
     public static List<Runnable> buildFarm(Location base,
@@ -312,6 +324,24 @@ public final class HouseBuilder {
         tasks.add(() -> sb.set(ox + craftL[0], oy + 1, oz + craftL[1], Material.CRAFTING_TABLE));
 
         return tasks;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  SURCHARGE courte de buildHouse (compatible avec Disposition)      */
+    /* ------------------------------------------------------------------ */
+    public static List<Runnable> buildHouse(int x, int y, int z,
+                                            int size, int rot,
+                                            List<Material> roadPalette,
+                                            List<Material> roofPalette,
+                                            List<Material> wallLogs,
+                                            List<Material> wallPlanks,
+                                            TerrainManager.SetBlock sb) {
+        // redirige vers la version longue mais avec des choix aléatoires simples
+        return buildHouse(null,
+                          new Location(null, x, y, z),
+                          size, rot,
+                          wallLogs, wallPlanks, roofPalette,
+                          sb, new Random(), 0);
     }
 
     /* ------------------------------------------------------------------ */

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: MinePlugin
 version: 1.1-SNAPSHOT          # ↑ incrémente si tu veux distinguer les builds
 main: org.example.MinePlugin
-api-version: "1.21.4"
+api-version: "1.20"
 
 commands:
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <!-- Le plugin doit être compilé en Java 17 -->
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <paper.version>1.21.4-R0.1-SNAPSHOT</paper.version>            <!-- Paper API -->
+        <paper.version>1.20.6-R0.1-SNAPSHOT</paper.version>            <!-- Paper API -->
     </properties>
 
     <!-- ========== DÉPÔTS ========== -->


### PR DESCRIPTION
## Summary
- update Paper snapshot to 1.20.6
- correct api version in `plugin.yml`
- replace `Disposition` with static utility version
- add `paintRoad` and a short `buildHouse` overload in `HouseBuilder`

## Testing
- `mvn -q package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684cb00d89f4832e9630116ec598ee2f